### PR TITLE
Add in an initial drop table statement to be able to re-run all cells…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+.ipython/
 
 # IPython
 ipython_config.py

--- a/spark/notebooks/Iceberg - Getting Started.ipynb
+++ b/spark/notebooks/Iceberg - Getting Started.ipynb
@@ -37,6 +37,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "747bee98",
+   "metadata": {},
+   "source": [
+    "To be able to rerun the notebook several times, let's drop the table if it exists to start fresh."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "930682ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "\n",
+    "DROP TABLE IF EXISTS taxis"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "1c37ca92",
@@ -56,7 +76,7 @@
    "source": [
     "%%sql\n",
     "\n",
-    "DESCRIBE TABLE taxis"
+    "DESCRIBE EXTENDED taxis"
    ]
   },
   {
@@ -184,8 +204,7 @@
     "%%sql\n",
     "\n",
     "DELETE FROM taxis\n",
-    "WHERE fare_per_distance_unit > 4.0\n",
-    "OR distance > 2.0"
+    "WHERE fare_per_distance_unit > 4.0 OR distance > 2.0"
    ]
   },
   {
@@ -398,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0ff90d9",
+   "id": "5c2c6f7a",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
… multiple times

Right now, if we click run all cells, and then we run all cells again, the notebook will fail due to the renamed columns.

Because there is no SQL support for `RENAME COLUMN IF EXISTS` or anything like it (in SQL), we've decided to add an initial `DROP TABLE IF EXISTS` statement.

I've also changed the `DESCRIBE TABLE` to be `DESCRIBE EXTENDED` so that people can see the full catalog name, that it's an iceberg table, etc (mostly the fact that we've otherwise not referenced that it's `demo.taxis).