### PR TITLE
Upgrade Spark to 3.2.1 and use Iceberg 0.13.1

### DIFF
--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -43,9 +43,9 @@ RUN curl https://dlcdn.apache.org/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
 RUN tar xvzf hadoop-3.3.1.tar.gz --directory /opt/hadoop --strip-components 1 \
  && rm -rf hadoop-3.3.1.tar.gz
 
-RUN curl https://dlcdn.apache.org/spark/spark-3.1.2/spark-3.1.2-bin-hadoop3.2.tgz -o spark-3.1.2-bin-hadoop3.2.tgz
-RUN tar xvzf spark-3.1.2-bin-hadoop3.2.tgz --directory /opt/spark --strip-components 1 \
- && rm -rf spark-3.1.2-bin-hadoop3.2.tgz
+RUN curl https://dlcdn.apache.org/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz -o spark-3.2.1-bin-hadoop3.2.tgz
+RUN tar xvzf spark-3.2.1-bin-hadoop3.2.tgz --directory /opt/spark --strip-components 1 \
+ && rm -rf spark-3.2.1-bin-hadoop3.2.tgz
 
 RUN curl https://jdbc.postgresql.org/download/postgresql-42.2.24.jar -o postgresql-42.2.24.jar \
  && cp postgresql-42.2.24.jar /opt/spark/jars \

--- a/spark/spark-defaults.conf
+++ b/spark/spark-defaults.conf
@@ -19,7 +19,7 @@
 # This is useful for setting default environmental settings.
 
 # Example:
-spark.jars.packages                    org.apache.iceberg:iceberg-spark3-runtime:0.12.1
+spark.jars.packages                    org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:0.13.1
 spark.sql.extensions                   org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
 spark.sql.catalog.demo                 org.apache.iceberg.spark.SparkCatalog
 spark.sql.catalog.demo.catalog-impl    org.apache.iceberg.jdbc.JdbcCatalog


### PR DESCRIPTION
I've tested this locally and it works.

Opening this as a draft, as we will need to release an updated image to dockerhub.

I would propose that we start by versioning the images according to `tabualrio/spark-iceberg:${spark_version}_${iceberg_versions`, so `tabulario/spark-iceberg:3.2.1_0.13.1`. We'd still need to account for image changes that occur without a version change.

In addition to versioning, I would still keep the most recent image on `latest` (and reserve that tag for mutable images).

In the case that we keep going with `latest`, we definitely need to provide clear instructions on how to remove the image and redownload the newest "latest". I think that `docker-compose kill && docker-compose rm && docker-compose pull` should cover it.

We might only need to tag the images for archival purposes and then rely on `latest` the rest of the time. Alternatively (or more likely, in addition), we could provide instructions for building the images locally.