### PR TITLE
Add a docker-compose-w-minio.yml

### DIFF
--- a/docker-compose-w-minio.yml
+++ b/docker-compose-w-minio.yml
@@ -1,0 +1,67 @@
+version: "3"
+
+services:
+  spark-iceberg:
+    image: tabulario/spark-iceberg
+    depends_on:
+      - postgres
+    container_name: spark-iceberg
+    environment:
+      - SPARK_HOME=/opt/spark
+      - PYSPARK_PYTON=/usr/bin/python3.9
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_REGION=us-east-1
+    volumes:
+      - ./warehouse:/home/iceberg/warehouse
+      - ./notebooks:/home/iceberg/notebooks/notebooks
+    ports:
+      - 8888:8888
+      - 8080:8080
+      - 18080:18080
+    entrypoint: /bin/sh
+    command: >
+      -c "
+      echo \"
+      spark.sql.catalog.demo.io-impl         org.apache.iceberg.aws.s3.S3FileIO \n
+      spark.sql.catalog.demo.warehouse       s3://warehouse \n
+      spark.sql.catalog.demo.s3.endpoint     http://minio:9000 \n
+      \" >> /opt/spark/conf/spark-defaults.conf && ./entrypoint.sh
+      "
+  postgres:
+    image: postgres:13.4-bullseye
+    container_name: postgres
+    environment:
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=demo_catalog
+    volumes:
+      - ./postgres/data:/var/lib/postgresql/data
+  minio:
+    image: minio/minio
+    container_name: minio
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
+    ports:
+      - 9001:9001
+      - 9000:9000
+    command: ["server", "/data", "--console-address", ":9001"]
+  mc:
+    depends_on:
+      - minio
+    image: minio/mc
+    container_name: mc
+    environment:
+      - AWS_ACCESS_KEY_ID=demo
+      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_REGION=us-east-1
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc rm -r --force minio/warehouse;
+      /usr/bin/mc mb minio/warehouse;
+      /usr/bin/mc policy set public minio/warehouse;
+      exit 0;
+      "


### PR DESCRIPTION
This adds a variation of the docker-compose that uses a local minio container + S3FileIO for storage (instead of a local directory + HadoopFileIO). This is covered in [this](https://tabular.io/blog/minio/) blog post.