### PR TITLE
Update README with link to dockerhub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ docker image rm tabulario/spark-iceberg && docker-compose pull
 
 For more information on getting started with using Iceberg, checkout
 the [Getting Started](https://iceberg.apache.org/getting-started/) guide in the official docs.
+
+The repository for the docker image is [located on dockerhub](https://hub.docker.com/r/tabulario/spark-iceberg).


### PR DESCRIPTION
Adds a link to the dockerhub repository to the README.

I wasn't quite sure where to place this, so I just added it to the bottom. Please feel free to suggest a better location / header.