### PR TITLE
Infra - Add script to push new image to Dockerhub

### DIFF
--- a/dev/build-and-push-image.sh
+++ b/dev/build-and-push-image.sh
@@ -1,4 +1,68 @@
 #!/bin/bash
 
-docker buildx build -t tabulario/spark-iceberg:latest -t tabulario/spark-iceberg:3.2.1_0.13.1 --platform=linux/amd64,linux/arm64 ./spark --push
+set -e
+
+usage () {
+  echo "usage: $0 [-t <image_tag>]"
+  echo "  -t      Version tag of the image being pushed. Defaults to \"latest\""
+  echo "  -v      Turn on VERBOSE / DEBUG output"
+  exit 1
+}
+
+validate_tag_or_throw() {
+  if [[ ! "$1" =~ ^([a-z0-9\_])([\-\.\_a-z0-9]{0,127})$ ]]; then
+    echo "The image tag \"$1\" is invalid."
+    echo "  A valid image tag must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes."
+    echo "  A tag name may not start with a period or a dash and may contain a maximum of 128 characters"
+    exit 1
+  fi
+}
+
+# Default repository remote name
+REPOSITORY="tabulario"
+IMAGE_NAME="spark-iceberg"
+TAG="latest"
+
+while getopts "t:v" opt; do
+  case "${opt}" in
+    t)
+      TAG="${OPTARG}"
+      ;;
+    v)
+      set -x
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+shift $((OPTIND-1))
+
+if [[ -z "$TAG" ]]; then
+  echo "You must specify the image tag to be used via the -t switch. If left empty, then \"latest\" will be used"
+  usage
+fi
+
+# Validate docker is installed
+if ! command -v docker  &> /dev/null; then
+  echo "The docker command could not be found. Please install docker and rerun."
+  exit
+fi
+
+# Validate docker is on
+if ! docker info > /dev/null 2>&1; then
+  echo "The docker daemon is not running or accessible. Please start docker and rerun."
+  usage
+fi
+
+# Validate the tag is acceptable
+validate_tag_or_throw "$TAG"
+
+# Build full image target and log.
+IMAGE_TARGET=${REPOSITORY}/${IMAGE_NAME}:${TAG}
+
+echo "Building and pushing multi-architecture image as ${IMAGE_TARGET} for platforms linux/amd64 and linux/arm64"
+
+docker buildx build -t ${IMAGE_TARGET} --platform=linux/amd64,linux/arm64 ./spark --load
 

--- a/dev/build-and-push-image.sh
+++ b/dev/build-and-push-image.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker buildx build -t tabulario/spark-iceberg:latest -t tabulario/spark-iceberg:3.2.1_0.13.1 --platform=linux/amd64,linux/arm64 ./spark --push
+


### PR DESCRIPTION
Adds a simple shell script to push the image as a multi-platform image to dockerhub.

This script takes in the tag as an argument, and is set up to make it easy to change to support different repositories etc. It also checks if docker is installed and running, as well as validates the image tag is a valid image tag.

The tag defaults to latest if not provided.