### PR TITLE
Add missing namespace definition in notebook example

### DIFF
--- a/spark/notebooks/Iceberg - An Introduction to the Iceberg Java API.ipynb
+++ b/spark/notebooks/Iceberg - An Introduction to the Iceberg Java API.ipynb
@@ -96,7 +96,9 @@
    "outputs": [],
    "source": [
     "import org.apache.iceberg.catalog.TableIdentifier;\n",
+    "import org.apache.iceberg.catalog.Namespace;\n",
     "\n",
+    "Namespace nyc = Namespace.of(\"nyc\");\n",
     "TableIdentifier name = TableIdentifier.of(nyc, \"logs\");\n",
     "name"
    ]
@@ -318,6 +320,14 @@
     "DataFile dataFile = task.files().iterator().next().file();\n",
     "System.out.println(dataFile);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0240262c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Bugfix in java api notebook. Missing an import and definition of the nyc namespace.