### PR TITLE
Update Iceberg-Spark-runtime to use 3.2.1_0.14.0

### DIFF
--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -47,8 +47,8 @@ RUN curl https://jdbc.postgresql.org/download/postgresql-42.2.24.jar -o postgres
  && rm postgresql-42.2.24.jar
 
 # Download iceberg spark runtime
-RUN curl https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/0.13.1/iceberg-spark-runtime-3.2_2.12-0.13.1.jar -Lo iceberg-spark-runtime-3.2_2.12-0.13.1.jar \
- && mv iceberg-spark-runtime-3.2_2.12-0.13.1.jar /opt/spark/jars
+RUN curl https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/0.14.0/iceberg-spark-runtime-3.2_2.12-0.14.0.jar -Lo iceberg-spark-runtime-3.2_2.12-0.14.0.jar \
+ && mv iceberg-spark-runtime-3.2_2.12-0.14.0.jar /opt/spark/jars
 
 # Download Java AWS SDK
 RUN curl https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.17.165/bundle-2.17.165.jar -Lo bundle-2.17.165.jar \


### PR DESCRIPTION
This updates the main branch to use the new 0.14.0 release. I confirmed that the notebooks run without any issues using this new version. Once this is in I think we should cut a `3.2.1_0.14.0` branch and deploy that tag to dockerhub. Then we can start on updating the main branch to Spark 3.3.0 using the Iceberg-Spark runtime for Spark 3.3 and Iceberg 0.14.0.