### PR TITLE
Updated Spark to 3.3.0 and the Iceberg-Spark-runtime to 3.3_2.12-0.14.0

### DIFF
--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -37,9 +37,9 @@ RUN mkdir -p ${HADOOP_HOME} && mkdir -p ${SPARK_HOME}
 WORKDIR ${SPARK_HOME}
 
 # Download spark
-RUN curl https://archive.apache.org/dist/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz -o spark-3.2.1-bin-hadoop3.2.tgz \
- && tar xvzf spark-3.2.1-bin-hadoop3.2.tgz --directory /opt/spark --strip-components 1 \
- && rm -rf spark-3.2.1-bin-hadoop3.2.tgz
+RUN curl https://dlcdn.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz -o spark-3.3.0-bin-hadoop3.tgz \
+ && tar xvzf spark-3.3.0-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
+ && rm -rf spark-3.3.0-bin-hadoop3.tgz
 
 # Download postgres connector jar
 RUN curl https://jdbc.postgresql.org/download/postgresql-42.2.24.jar -o postgresql-42.2.24.jar \
@@ -47,8 +47,8 @@ RUN curl https://jdbc.postgresql.org/download/postgresql-42.2.24.jar -o postgres
  && rm postgresql-42.2.24.jar
 
 # Download iceberg spark runtime
-RUN curl https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/0.14.0/iceberg-spark-runtime-3.2_2.12-0.14.0.jar -Lo iceberg-spark-runtime-3.2_2.12-0.14.0.jar \
- && mv iceberg-spark-runtime-3.2_2.12-0.14.0.jar /opt/spark/jars
+RUN curl https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/0.14.0/iceberg-spark-runtime-3.3_2.12-0.14.0.jar -Lo iceberg-spark-runtime-3.3_2.12-0.14.0.jar \
+ && mv iceberg-spark-runtime-3.3_2.12-0.14.0.jar /opt/spark/jars
 
 # Download Java AWS SDK
 RUN curl https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.17.165/bundle-2.17.165.jar -Lo bundle-2.17.165.jar \


### PR DESCRIPTION
This updates Spark to `3.3.0` and the Iceberg-Spark runtime to `3.3_2.12-0.14.0`. I confirmed that all of the notebooks run without any errors.