### PR TITLE
Add Hive

### DIFF
--- a/docker-compose-w-minio.yml
+++ b/docker-compose-w-minio.yml
@@ -19,6 +19,7 @@ services:
     ports:
       - 8888:8888
       - 8080:8080
+      - 10000:10000
       - 18080:18080
     entrypoint: /bin/sh
     command: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   spark-iceberg:
     image: tabulario/spark-iceberg
+    build: spark/
     depends_on:
       - postgres
     volumes:
@@ -11,6 +12,7 @@ services:
     ports:
       - 8888:8888
       - 8080:8080
+      - 10000:10000
       - 18080:18080
   postgres:
     image: postgres:13.4-bullseye

--- a/spark/entrypoint.sh
+++ b/spark/entrypoint.sh
@@ -3,6 +3,7 @@
 start-master.sh -p 7077
 start-worker.sh spark://spark-iceberg:7077
 start-history-server.sh
+start-thriftserver.sh
 
 # Entrypoint, for example notebook, pyspark or spark-sql
 if [[ $# -gt 0 ]] ; then


### PR DESCRIPTION
Why nut?

```
➜  docker-spark-iceberg git:(fd-fix-config) ✗ docker exec -t -i 05357a90a6e7 bash
root@05357a90a6e7:/opt/spark# ./sbin/start-thriftserver.sh
starting org.apache.spark.sql.hive.thriftserver.HiveThriftServer2, logging to /opt/spark/logs/spark--org.apache.spark.sql.hive.thriftserver.HiveThriftServer2-1-05357a90a6e7.out
root@05357a90a6e7:/opt/spark# ./bin/beeline
Beeline version 2.3.9 by Apache Hive
beeline> !connect jdbc:hive2://localhost:10000/nyc
Connecting to jdbc:hive2://localhost:10000/nyc
Enter username for jdbc:hive2://localhost:10000/nyc: root
Enter password for jdbc:hive2://localhost:10000/nyc:
Connected to: Spark SQL (version 3.3.0)
Driver: Hive JDBC (version 2.3.9)
Transaction isolation: TRANSACTION_REPEATABLE_READ
0: jdbc:hive2://localhost:10000/nyc> show tables;
+------------+---------------+--------------+
| namespace  |   tableName   | isTemporary  |
+------------+---------------+--------------+
| nyc        | taxis_sample  | false        |
+------------+---------------+--------------+
1 row selected (0.463 seconds)
0: jdbc:hive2://localhost:10000/nyc> select count(1) from taxis_sample;
+-----------+
| count(1)  |
+-----------+
| 9071244   |
+-----------+
1 row selected (1.721 seconds)
```