### PR TITLE
Keep the mc container alive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,5 +59,5 @@ services:
       /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;
-      exit 0;
+      tail -f /dev/null
       "


### PR DESCRIPTION
If you run `docker-compose up`, create some tables, and then run `docker-compose up` again, all the tables will be corrupted. This is because `mc` will run again, and will remove all the files in the bucket.