### PR TITLE
Use separate derby folder for thriftserver

### DIFF
--- a/spark/entrypoint.sh
+++ b/spark/entrypoint.sh
@@ -20,7 +20,7 @@
 start-master.sh -p 7077
 start-worker.sh spark://spark-iceberg:7077
 start-history-server.sh
-start-thriftserver.sh
+start-thriftserver.sh  --driver-java-options "-Dderby.system.home=/tmp/derby"
 
 # Entrypoint, for example notebook, pyspark or spark-sql
 if [[ $# -gt 0 ]] ; then


### PR DESCRIPTION
This is so that the spark shell can still be started while the thriftserver is running