### PR TITLE
Python: Remove `typing-extensions` pin

### DIFF
--- a/spark/requirements.txt
+++ b/spark/requirements.txt
@@ -5,4 +5,3 @@ jupysql==0.5.2
 matplotlib==3.6.3
 scipy==1.10.0
 duckdb-engine==0.6.8
-typing-extensions==4.5.0 # workaround to fix pydantic issue


### PR DESCRIPTION
It looks like they already released 4.6.2 that fixes it.