### PR TITLE
Update notebook

### DIFF
--- a/spark/notebooks/Iceberg - Write-Audit-Publish (WAP) with Branches.ipynb
+++ b/spark/notebooks/Iceberg - Write-Audit-Publish (WAP) with Branches.ipynb
@@ -419,7 +419,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expected_boroughs = {\"Queens\", \"Brooklyn\", \"Bronx\", \"Staten Island\"}"
+    "expected_boroughs = {\"Queens\", \"Brooklyn\", \"Bronx\"}"
    ]
   },
   {


### PR DESCRIPTION
The dataset has been updated:
https://data.cityofnewyork.us/City-Government/Film-Permits/tg4x-b46p/about_data

Looks like Staten Island has been removed