### PR TITLE
Update dockerfile to add AzureFileIO runtime

### DIFF
--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -67,6 +67,9 @@ RUN curl -s https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-aws-bundle
 # Download GCP bundle
 RUN curl -s https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-gcp-bundle/${ICEBERG_VERSION}/iceberg-gcp-bundle-${ICEBERG_VERSION}.jar -Lo /opt/spark/jars/iceberg-gcp-bundle-${ICEBERG_VERSION}.jar
 
+# Download Azure bundle
+RUN curl -s https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-azure-bundle/${ICEBERG_VERSION}/iceberg-azure-bundle-${ICEBERG_VERSION}.jar -Lo /opt/spark/jars/iceberg-azure-bundle-${ICEBERG_VERSION}.jar
+
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
  && unzip awscliv2.zip \


### PR DESCRIPTION
This PR adds the iceberg-azure bundle
Without this change, when using the AzureFileIO, queries fail with the below error
```
IllegalArgumentException: Cannot initialize FileIO implementation org.apache.iceberg.azure.adlsv2.ADLSFileIO: Cannot find constructor for interface org.apache.iceberg.io.FileIO
	Missing org.apache.iceberg.azure.adlsv2.ADLSFileIO [java.lang.NoClassDefFoundError: com/azure/storage/file/datalake/models/DataLakeStorageException]
```
Confirmed, this error no longer happens after adding the runtime