### PR TITLE
fix : issue #223 Update docker-compose.yml syntax issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - AWS_REGION=us-east-1
     entrypoint: >
       /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc anonymous set public minio/warehouse;


### PR DESCRIPTION
error : mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag.  ...waiting...
 
mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag.  ...waiting...


reference : https://min.io/docs/minio/linux/reference/minio-mc.html