### PR TITLE
Download Spark tarball via closer.lua

### DIFF
--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -48,7 +48,7 @@ ENV ICEBERG_VERSION=1.9.0
 
 # Download spark
 RUN mkdir -p ${SPARK_HOME} \
- && curl https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+ && curl "https://www.apache.org/dyn/closer.lua/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz?action=download" -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xvzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
  && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 

--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -48,7 +48,7 @@ ENV ICEBERG_VERSION=1.9.0
 
 # Download spark
 RUN mkdir -p ${SPARK_HOME} \
- && curl "https://www.apache.org/dyn/closer.lua/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz?action=download" -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+ && curl -L "https://www.apache.org/dyn/closer.lua/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz?action=download" -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xvzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
  && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 


### PR DESCRIPTION
Spark 3.5.6 is no longer available from `dlcdn.apache.org`, since 3.5.8 is the current release, so CI checks are [failing](https://github.com/databricks/docker-spark-iceberg/actions/runs/20206978889/job/58007019699#step:4:2092).

This PR updates the download link to use Apache Infra's [`closer.lua` script](https://infra.apache.org/release-download-pages.html#closer), which works for all releases.  It redirects to `dlcdn` if release is present there, otherwise to the archives.

```bash
$ curl -L --head 'https://www.apache.org/dyn/closer.lua/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz?action=download'
HTTP/2 302
...
location: https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz
...

HTTP/1.1 200 OK
...


$ curl -L --head 'https://www.apache.org/dyn/closer.lua/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3.tgz?action=download'
HTTP/2 302 
...
location: https://dlcdn.apache.org/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3.tgz
...

HTTP/2 200 
...
```

Note: Spark should probably be bumped to 3.5.8 to stay current and avoid unnecessarily using archive storage.  However, this change is still useful for interim periods between release archival and version bump.